### PR TITLE
Update for Python 3.14 and Django 6.0 readiness

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -121,13 +121,16 @@ jobs:
   tests:
     name: Python ${{ matrix.python-version }} / ${{ matrix.db }} / Django ${{ matrix.django-version}}
     runs-on: ubuntu-latest
-#    continue-on-error: ${{ matrix.django-version == '~=5.0' }}
+    continue-on-error: ${{ matrix.django-version == '~=6.0' || matrix.python-version == '3.14' }}
     strategy:
-      max-parallel: 4
+      max-parallel: 6
       matrix:
         db: [ sqlite, mariadb ]
-        django-version: [ "~=5.0" ]
-        python-version: ["3.12", "3.13" ]
+        django-version: [ "~=5.2", "~=6.0" ]
+        python-version: ["3.12", "3.13", "3.14" ]
+        exclude:
+          - python-version: "3.12"
+            django-version: "~=6.0"
 
     services:
       mariadb:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@ default_language_version:
   python: python3.13
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v5.0.0
     hooks:
       - id: check-added-large-files
         args: [ '--maxkb=500' ]
@@ -20,11 +20,8 @@ repos:
         exclude: .idea/.*
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    # Ruff version.
-    rev: v0.7.3
+    rev: v0.8.3
     hooks:
-      # Run the linter.
       - id: ruff
         args: [ --fix ]
-      # Run the formatter.
       - id: ruff-format

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "pivotal-app-metrics"
 dynamic = ["version"]
 description = "django-app-metrics is a reusable Django application for tracking and emailing application metrics."
 readme = "README.md"
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 authors = [
     { name = "Pivotal Energy Solutions", email = "steve@pivotal.energy" },
 ]
@@ -20,18 +20,19 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Django",
-    "Framework :: Django :: 5.0",
+    "Framework :: Django :: 5.2",
+    "Framework :: Django :: 6.0",
     "Intended Audience :: Developers",
     "License :: Other/Proprietary License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Utilities",
 ]
 dependencies = [
-    "django>=5.0",
+    "django>=5.2",
     "celery",
 ]
 
@@ -74,13 +75,27 @@ include = [
 
 [tool.black]
 line-length = 100
-target-version = ['py311']
+target-version = ['py312']
 include = '\.pyi?$'
 exclude = '(\.git|.venv|_build|build|dist|.*\/__pycache__\/)'
 
 [tool.ruff]
+exclude = [".bzr", ".direnv", ".eggs", ".git", ".mypy_cache", ".nox", ".pytype", ".ruff_cache", ".svn", ".tox", ".venv", "__pypackages__", "_build", "build", "dist", "node_modules"]
 line-length = 100
-lint.ignore = ["F401", "F405"]
+indent-width = 4
+target-version = "py312"
+
+[tool.ruff.lint]
+ignore = ["F401", "E402", "F405"]
+fixable = ["ALL"]
+unfixable = []
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
 
 [tool.bandit]
 targets = ['app_metrics']


### PR DESCRIPTION
## Summary
- Update pyproject.toml classifiers for Python 3.12/3.13/3.14 and Django 5.2/6.0
- Update requires-python to >=3.12
- Modernize ruff configuration with proper lint and format sections
- Update black target-version to py312
- Update pre-commit hooks to v5.0.0 and ruff to v0.8.3
- Update GitHub CI test matrix for Python 3.12/3.13/3.14 and Django 5.2/6.0
- Add continue-on-error for Django 6.0 and Python 3.14 in CI

## Test plan
- [ ] CI passes for Python 3.12/3.13 with Django 5.2
- [ ] CI runs (may fail) for Python 3.14 and Django 6.0 with continue-on-error

🤖 Generated with [Claude Code](https://claude.com/claude-code)