### PR TITLE
Update CI workflow and ruff to v0.14.8

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,7 @@ name: Django App Metrics Tests
 
 on:
   push:
+  merge_group:
   schedule:
     - cron: '0 1 * * 5'
 
@@ -31,27 +32,8 @@ jobs:
       - name: outdated
         run: pip list --outdated --not-required --user | grep . && echo "There are outdated packages" && exit 1 || echo "All packages up to date"
 
-  black:
-    name: Black
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install .[test]
-
-      - name: Black
-        run: black --check .
-
   ruff:
-    name: Ruff
+    name: Ruff Format
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -66,28 +48,11 @@ jobs:
           pip install .
           pip install .[test]
 
-      - name: Ruff
+      - name: Ruff Format Check
+        run: ruff format --check .
+
+      - name: Ruff Lint Check
         run: ruff check
-
-  pre-commit:
-    name: Pre-Commit
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-          cache: 'pip'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install .
-          pip install .[test]
-          pre-commit install
-
-      - name: Pre-Commit
-        run: pre-commit run --all-files --show-diff-on-failure
 
   security:
     name: Bandit Security
@@ -219,8 +184,8 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    needs: ['outdated', 'black', 'pre-commit', 'security', 'tests', 'coverage']
-    if: github.ref == 'refs/heads/master'  # Only run on master
+    needs: ['outdated', 'ruff', 'security', 'tests', 'coverage']
+    if: always() && github.ref == 'refs/heads/master' && !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled')
     permissions: write-all
     outputs:
       bumped: ${{ steps.release.outputs.bumped }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,7 +20,7 @@ repos:
         exclude: .idea/.*
       - id: check-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.3
+    rev: v0.14.8
     hooks:
       - id: ruff
         args: [ --fix ]


### PR DESCRIPTION
## Summary
- Update CI workflow: remove Black/pre-commit jobs, add merge queue support
- Update ruff to v0.14.8 in pre-commit config
- Add `always()` pattern to release job to prevent skipped propagation

## Test plan
- [x] Ruff format check passes
- [x] Ruff lint check passes
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)